### PR TITLE
fixed: constants.ts

### DIFF
--- a/market-bot/src/external/AlphaVantage.ts
+++ b/market-bot/src/external/AlphaVantage.ts
@@ -1,5 +1,5 @@
 import { IHttp, IRead } from '@rocket.chat/apps-engine/definition/accessors';
-import { ALPHA_VANTAGE_API_KEY_SETTING_ID } from '../constants';
+import { ALPHA_VANTAGE_API_KEY_SETTING_ID } from './constants';
 
 export interface AlphaVantageMarketData {
     symbol: string;

--- a/market-bot/src/external/constants.ts
+++ b/market-bot/src/external/constants.ts
@@ -1,0 +1,1 @@
+export const ALPHA_VANTAGE_API_KEY_SETTING_ID = 'alpha_vantage_api_key';


### PR DESCRIPTION
@Spiral-Memory 
Restored the missing constant for `alpha_vantage_api_key`  in `constants.ts` and confirmed it's being referenced correctly.
Thanks!